### PR TITLE
Feature: SVG (Ref: #14)

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,0 +1,5 @@
+# Base Theme Documentation
+
+## Table of Contents
+
+1. [SVG Sprites](/docs/svg-sprites/readme.md)

--- a/docs/svg-sprites/readme.md
+++ b/docs/svg-sprites/readme.md
@@ -1,0 +1,45 @@
+# SVG Sprites
+
+We prefer to use external SVG sprite where possible over including SVG's inline through base encoding.
+
+## Create a new sprite
+
+1. Add a new SVG Spritemap Plugin to the webpack config:
+
+```js
+new SVGSpritemapPlugin(
+  ['resources/svg/{sprite-name}/*.svg'],
+  {
+    input: {},
+    output: {
+      filename: '/svg/{sprite-name}.svg',
+      svg: {},
+      svgo: true,
+    },
+    sprite: {
+      prefix: false,
+      gutter: false,
+      generate: {
+        title: false,
+      }
+    }
+  }
+),
+```
+
+## Adding an SVG to the sprite
+
+1. Place the SVG file inside the sprite directory, `./resources/svg/{sprite-name}/{filename}.svg`.
+2. Run the `npm run build` command to compile the SVG sprite.
+3. Your SVG will be added to the sprite at `./assets/svg/{sprite-name}.svg`.
+
+## Using an image from the sprite
+
+```php
+printf(
+  '<svg aria-hidden="%3$s"><use xlink:href="%1$s"><title>%2$s</title></use></svg>',
+  esc_url( get_stylesheet_directory_uri() . '/assets/svg/{sprite-name}.svg#{sprite}' ),
+  esc_html__( '{Sprite}', 'base-theme' ),
+  'true'
+);
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
                 "npm-run-all": "^4.1.5",
                 "path": "^0.12.7",
                 "rtlcss-webpack-plugin": "^4.0.7",
-                "webpack-remove-empty-scripts": "^1.1.1"
+                "svg-spritemap-webpack-plugin": "^4.7.0",
+                "webpack-remove-empty-scripts": "^1.1.4"
             },
             "engines": {
                 "node": "^20.9.0",
@@ -5773,6 +5774,16 @@
             "engines": {
                 "node": ">=18.12.0",
                 "npm": ">=8.19.2"
+            }
+        },
+        "node_modules/@xmldom/xmldom": {
+            "version": "0.8.10",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+            "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
             }
         },
         "node_modules/@xtuc/ieee754": {
@@ -14531,6 +14542,16 @@
                 "webpack": "^5.0.0"
             }
         },
+        "node_modules/mini-svg-data-uri": {
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
+            "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "mini-svg-data-uri": "cli.js"
+            }
+        },
         "node_modules/minimalistic-assert": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -18808,6 +18829,14 @@
             "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
             "dev": true
         },
+        "node_modules/stable": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+            "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
+            "deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/stack-utils": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -19597,17 +19626,271 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/svg-element-attributes": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/svg-element-attributes/-/svg-element-attributes-1.3.1.tgz",
+            "integrity": "sha512-Bh05dSOnJBf3miNMqpsormfNtfidA/GxQVakhtn0T4DECWKeXQRQUceYjJ+OxYiiLdGe4Jo9iFV8wICFapFeIA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/svg-parser": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
             "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==",
             "dev": true
         },
+        "node_modules/svg-spritemap-webpack-plugin": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/svg-spritemap-webpack-plugin/-/svg-spritemap-webpack-plugin-4.7.0.tgz",
+            "integrity": "sha512-IgatRk4bVZkLqIGZVn7i0XyN4F3yL3+OQ3RdL/25AFwkkLtLuWPW7u0J8NdesebHYGAba7iPtiFe0vegblbB2Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@xmldom/xmldom": "^0.8.2",
+                "glob": "^8.0.3",
+                "joi": "^17.6.0",
+                "loader-utils": "^3.2.0",
+                "lodash": "^4.17.21",
+                "mini-svg-data-uri": "^1.4.4",
+                "mkdirp": "^1.0.4",
+                "svg-element-attributes": "^1.3.1",
+                "svg4everybody": "^2.1.9",
+                "svgo": "^2.8.0",
+                "webpack-merge": "^5.8.0",
+                "webpack-sources": "^3.2.3"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "peerDependencies": {
+                "webpack": "^5.0.0"
+            }
+        },
+        "node_modules/svg-spritemap-webpack-plugin/node_modules/commander": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/svg-spritemap-webpack-plugin/node_modules/css-select": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
+            "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "boolbase": "^1.0.0",
+                "css-what": "^6.0.1",
+                "domhandler": "^4.3.1",
+                "domutils": "^2.8.0",
+                "nth-check": "^2.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
+        "node_modules/svg-spritemap-webpack-plugin/node_modules/css-tree": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+            "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mdn-data": "2.0.14",
+                "source-map": "^0.6.1"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/svg-spritemap-webpack-plugin/node_modules/csso": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
+            "integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "css-tree": "^1.1.2"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/svg-spritemap-webpack-plugin/node_modules/dom-serializer": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+            "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "domelementtype": "^2.0.1",
+                "domhandler": "^4.2.0",
+                "entities": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+            }
+        },
+        "node_modules/svg-spritemap-webpack-plugin/node_modules/domhandler": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+            "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "domelementtype": "^2.2.0"
+            },
+            "engines": {
+                "node": ">= 4"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domhandler?sponsor=1"
+            }
+        },
+        "node_modules/svg-spritemap-webpack-plugin/node_modules/domutils": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+            "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "dom-serializer": "^1.0.1",
+                "domelementtype": "^2.2.0",
+                "domhandler": "^4.2.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domutils?sponsor=1"
+            }
+        },
+        "node_modules/svg-spritemap-webpack-plugin/node_modules/entities": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/svg-spritemap-webpack-plugin/node_modules/glob": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^5.0.1",
+                "once": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/svg-spritemap-webpack-plugin/node_modules/loader-utils": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.3.1.tgz",
+            "integrity": "sha512-FMJTLMXfCLMLfJxcX9PFqX5qD88Z5MRGaZCVzfuqeZSPsyiBzs+pahDQjbIWz2QIzPZz0NX9Zy4FX3lmK6YHIg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12.13.0"
+            }
+        },
+        "node_modules/svg-spritemap-webpack-plugin/node_modules/mdn-data": {
+            "version": "2.0.14",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+            "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+            "dev": true,
+            "license": "CC0-1.0"
+        },
+        "node_modules/svg-spritemap-webpack-plugin/node_modules/minimatch": {
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/svg-spritemap-webpack-plugin/node_modules/mkdirp": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/svg-spritemap-webpack-plugin/node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/svg-spritemap-webpack-plugin/node_modules/svgo": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
+            "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@trysound/sax": "0.2.0",
+                "commander": "^7.2.0",
+                "css-select": "^4.1.3",
+                "css-tree": "^1.1.3",
+                "csso": "^4.2.0",
+                "picocolors": "^1.0.0",
+                "stable": "^0.1.8"
+            },
+            "bin": {
+                "svgo": "bin/svgo"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
         "node_modules/svg-tags": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
             "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
             "dev": true
+        },
+        "node_modules/svg4everybody": {
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/svg4everybody/-/svg4everybody-2.1.9.tgz",
+            "integrity": "sha512-AS9WORVV/vk520ZHxGTlQzyDBizp/h6WyAYUbKhze/kwvQr43DwJpkIIPBomsUyKqN7N+h1deF92N9PmW+o+9A==",
+            "dev": true,
+            "license": "CC0-1.0",
+            "engines": {
+                "node": ">=0.8.0"
+            }
         },
         "node_modules/svgo": {
             "version": "3.3.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "npm-run-all": "^4.1.5",
         "path": "^0.12.7",
         "rtlcss-webpack-plugin": "^4.0.7",
+        "svg-spritemap-webpack-plugin": "^4.7.0",
         "webpack-remove-empty-scripts": "^1.1.1"
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,7 @@ This requires a `register()` method be used when WordPress actions and fillters 
 
 ## Base Theme Template Development
 
-To start improving **this** template  for the first time:
+To start improving **this** template for the first time:
 
 ### Install
 

--- a/src/Domain/GlobalStyles.php
+++ b/src/Domain/GlobalStyles.php
@@ -31,6 +31,16 @@ final class GlobalStyles extends Service implements Registrable
 		);
 
 		\add_action(
+			hook_name: 'wp_enqueue_scripts',
+			callback: [
+				$this,
+				'dequeue',
+			],
+			priority: 100,
+			accepted_args: 0
+		);
+
+		\add_action(
 			hook_name: 'admin_init',
 			callback: [ $this, 'editor' ],
 			priority: 10,
@@ -48,6 +58,11 @@ final class GlobalStyles extends Service implements Registrable
 			deps: $global_stylesheet['dependencies'],
 			ver: $global_stylesheet['version']
 		);
+	}
+
+	public function dequeue(): void
+	{
+		// \wp_dequeue_style( handle: 'global-styles' );
 	}
 
 	public function editor(): void

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,6 +17,8 @@ const RtlCssPlugin = require(
 	'rtlcss-webpack-plugin'
 );
 
+const SVGSpritemapPlugin = require('svg-spritemap-webpack-plugin');
+
 // Utilities.
 const path = require( 'path' );
 const { globSync } = require( 'glob' );
@@ -47,6 +49,11 @@ module.exports = (env) => {
 		{
 			...defaultConfig,
 			name: "Theme",
+			module: {
+				rules: [
+					...defaultConfig.module.rules,
+				],
+			},
 			entry: {
 				...getWebpackEntryPoints,
 				...blockStylesheets(),
@@ -79,7 +86,7 @@ module.exports = (env) => {
 						'resources/css/',
 						'editor.css'
 					),
-				}
+				},
 			},
 			output: {
 				...defaultConfig.output,
@@ -97,18 +104,36 @@ module.exports = (env) => {
 				new CopyPlugin({
 					patterns: [
 						{
-							from: './resources/fonts',
-							to: './assets/fonts',
-							noErrorOnMissing: true
+							from: 'resources/svg/*.svg',
+							to: "svg/[name][ext]",
+							noErrorOnMissing: true,
 						},
 						{
-							from: './resources/svg',
-							to: './assets/svg',
+							from: 'resources/fonts/',
+							to: "fonts/",
 							noErrorOnMissing: true
 						},
 					],
 				}),
-			]
+				new SVGSpritemapPlugin(
+					['resources/svg/icons/*.svg'],
+					{
+						input: {},
+						output: {
+							filename: '/svg/icons.svg',
+							svg: {},
+							svgo: true,
+						},
+						sprite: {
+							prefix: false,
+							gutter: false,
+							generate: {
+								title: false,
+							}
+						}
+					}
+				),
+			],
 		}
 	]
 };


### PR DESCRIPTION
# SVG Sprites

We prefer to use external SVG sprite where possible over including SVG's inline through base encoding.

## Create a new sprite

1. Add a new SVG Spritemap Plugin to the webpack config:

```js
new SVGSpritemapPlugin(
  ['resources/svg/{sprite-name}/*.svg'],
  {
    input: {},
    output: {
      filename: '/svg/{sprite-name}.svg',
      svg: {},
      svgo: true,
    },
    sprite: {
      prefix: false,
      gutter: false,
      generate: {
        title: false,
      }
    }
  }
),
```

## Adding an SVG to the sprite

1. Place the SVG file inside the sprite directory, `./resources/svg/{sprite-name}/{filename}.svg`.
2. Run the `npm run build` command to compile the SVG sprite.
3. Your SVG will be added to the sprite at `./assets/svg/{sprite-name}.svg`.

## Using an image from the sprite

```php
printf(
  '<svg aria-hidden="%3$s"><use xlink:href="%1$s"><title>%2$s</title></use></svg>',
  esc_url( get_stylesheet_directory_uri() . '/assets/svg/{sprite-name}.svg#{sprite}' ),
  esc_html__( '{Sprite}', 'base-theme' ),
  'true'
);
```