### PR TITLE
feat: initial MVP of animation service

### DIFF
--- a/resources/css/animation-editor.css
+++ b/resources/css/animation-editor.css
@@ -1,0 +1,12 @@
+/*
+ * Disable animations in editor contexts ONLY when preview classes are absent.
+ * This selector is more specific than Animate.css's .animate__jello etc.
+ * so it will override, but only when the :not() conditions are met.
+ */
+.block-editor-block-list__layout .animate__animated:not(.animate__preview):not(.animate__preview-temp),
+iframe[name="editor-canvas"] .animate__animated:not(.animate__preview):not(.animate__preview-temp) {
+	animation: none !important;
+	animation-duration: 0s !important;
+	animation-delay: 0s !important;
+}
+

--- a/resources/js/animation-editor.js
+++ b/resources/js/animation-editor.js
@@ -337,10 +337,19 @@ const AnimationControls = (props) => {
 };
 
 const addAnimationControls = (BlockEdit) => (props) => {
+	// Get the current block name to check if it's supported
+	const blockName = useSelect((select) => {
+		const { getBlockName } = select('core/block-editor');
+		return getBlockName(props.clientId);
+	}, [props.clientId]);
+
+	// Check if this block type is supported for animations
+	const isSupported = l10n.supportedBlocks && l10n.supportedBlocks.includes(blockName);
+
 	return (
 		<>
 			<BlockEdit {...props} />
-			<AnimationControls {...props} />
+			{isSupported && <AnimationControls {...props} />}
 		</>
 	);
 };

--- a/resources/js/animation-editor.js
+++ b/resources/js/animation-editor.js
@@ -1,0 +1,352 @@
+/**
+ * Animation Editor
+ *
+ * Registers a custom Gutenberg block sidebar panel for animation controls.
+ */
+
+import { addFilter } from '@wordpress/hooks';
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, PanelRow, SelectControl, RangeControl, ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect, createElement } from '@wordpress/element';
+
+const AnimationControls = (props) => {
+	const { attributes, setAttributes, clientId } = props;
+
+	const { updateBlockAttributes } = useDispatch('core/block-editor');
+
+	// Get current animation settings from block attributes only
+	const animationSettings = attributes?.animation || {};
+
+	// Helper function to apply Animate.css classes to DOM element
+	const applyAnimateClasses = (element, animationType, trigger = 'scroll') => {
+		if (!element || !animationType) return;
+
+		// Remove any existing animate classes
+		const existingClasses = element.className.split(' ').filter(cls =>
+			!cls.startsWith('animate__')
+		);
+
+		// Add the base animate class and specific animation
+		if (animationType) {
+			existingClasses.push('animate__animated', `animate__${animationType}`);
+
+			// Add trigger-specific classes if needed
+			if (trigger === 'hover') {
+				// For hover animations, we'll handle this with CSS :hover pseudo-class
+				element.setAttribute('data-animate-trigger', 'hover');
+			} else if (trigger === 'scroll') {
+				// For scroll animations, we'll add a class that JavaScript can detect
+				element.setAttribute('data-animate-trigger', 'scroll');
+			}
+		}
+
+		element.className = existingClasses.join(' ');
+	};
+
+	// Helper function to trigger preview animation
+	const triggerPreviewAnimation = (animationType, duration = 1000, delay = 0, blockClientId = clientId) => {
+		if (!blockClientId || !animationType) return;
+
+		// Find the element using our existing logic
+		const findElementInDocument = (doc) => {
+			const selectors = [
+				`[data-block="${blockClientId}"]`,
+				`#block-${blockClientId}`,
+				`.wp-block[data-block="${blockClientId}"]`,
+				`.block-editor-block-list__block[data-block="${blockClientId}"]`,
+				`.is-selected`,
+				`.block-editor-block-list__block.is-selected`,
+			];
+
+			for (const selector of selectors) {
+				const element = doc.querySelector(selector);
+				if (element) return element;
+			}
+			return null;
+		};
+
+		// Check main document first
+		let element = findElementInDocument(document);
+
+		// If not found, check iframe
+		if (!element) {
+			const iframes = document.querySelectorAll('iframe');
+			for (const iframe of iframes) {
+				try {
+					const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+					if (iframeDoc) {
+						element = findElementInDocument(iframeDoc);
+						if (element) break;
+					}
+				} catch (error) {
+					// Skip inaccessible iframes
+				}
+			}
+		}
+
+		if (element) {
+			// Remove any existing preview classes
+			element.classList.remove('animate__preview', 'animate__preview-temp');
+
+			// Ensure animation classes are present
+			if (!element.classList.contains('animate__animated')) {
+				element.classList.add('animate__animated');
+			}
+			if (!element.classList.contains(`animate__${animationType}`)) {
+				element.classList.add(`animate__${animationType}`);
+			}
+
+			// Set custom properties
+			element.style.setProperty('--animate-duration', `${duration}ms`);
+			element.style.setProperty('--animate-delay', `${delay}ms`);
+
+			// Force reflow
+			element.offsetHeight;
+
+			// Add preview class to trigger animation
+			element.classList.add('animate__preview');
+
+			// Remove preview class after animation completes
+			setTimeout(() => {
+				element.classList.remove('animate__preview');
+			}, duration + delay + 100);
+		}
+	};
+
+	const updateAnimation = (key, value) => {
+		// If animation type is being set to empty/none, clear the entire animation attribute
+		if (key === 'type' && (!value || value === '')) {
+			setAttributes({
+				animation: undefined, // Remove the animation attribute entirely
+			});
+
+			// Remove animation classes from DOM element
+			const blockElement = document.querySelector(`[data-block="${clientId}"]`);
+			if (blockElement) {
+				// Remove all animate classes
+				const existingClasses = blockElement.className.split(' ').filter(cls =>
+					!cls.startsWith('animate__')
+				);
+				blockElement.className = existingClasses.join(' ').trim();
+
+				// Remove CSS custom properties
+				blockElement.style.removeProperty('--animate-duration');
+				blockElement.style.removeProperty('--animate-delay');
+			}
+			return;
+		}
+
+		// Prepare the new structured animation attribute (attributes only, no className)
+		const currentAnimationAttr = attributes.animation || {};
+		const newStructuredAnimation = {
+			...currentAnimationAttr,
+			source: 'block', // Keep the source as block
+			[key]: value, // Update the specific key that changed
+		};
+
+		// Only store in animation attribute - PHP will handle CSS classes
+		setAttributes({
+			animation: newStructuredAnimation,
+		});
+
+		// Apply classes to the actual DOM element in the editor for preview (but animations are disabled by CSS)
+		const blockElement = document.querySelector(`[data-block="${clientId}"]`);
+		if (blockElement && newStructuredAnimation.type) {
+			applyAnimateClasses(blockElement, newStructuredAnimation.type, newStructuredAnimation.trigger);
+
+			// Set CSS custom properties for preview
+			if (newStructuredAnimation.duration) {
+				blockElement.style.setProperty('--animate-duration', `${newStructuredAnimation.duration}ms`);
+			}
+			if (newStructuredAnimation.delay) {
+				blockElement.style.setProperty('--animate-delay', `${newStructuredAnimation.delay}ms`);
+			}
+		}
+
+		// If animation type changed, trigger a preview
+		if (key === 'type' && value && value !== animationSettings.type) {
+			setTimeout(() => {
+				triggerPreviewAnimation(value, newStructuredAnimation.duration || 1000, newStructuredAnimation.delay || 0, clientId);
+			}, 50);
+		}
+	};
+
+	const animationTypes = [
+		{ label: __('None', 'base-theme'), value: '' },
+		...Object.entries(l10n.supportedAnimateCssAnimations).map(([value, label]) => ({
+			label,
+			value
+		}))
+	];
+
+	const triggerTypes = Object.entries(l10n.supportedTriggerTypes).map(([value, label]) => ({
+		label,
+		value
+	}));
+
+	// Apply animation classes to DOM element for editor preview only
+	useEffect(() => {
+		const blockElement = document.querySelector(`[data-block="${clientId}"]`);
+		if (!blockElement) return;
+
+		// If no animation type, clean up any existing animation classes
+		if (!animationSettings.type) {
+			// Remove all animate classes
+			const existingClasses = blockElement.className.split(' ').filter(cls =>
+				!cls.startsWith('animate__')
+			);
+			blockElement.className = existingClasses.join(' ').trim();
+
+			// Remove CSS custom properties
+			blockElement.style.removeProperty('--animate-duration');
+			blockElement.style.removeProperty('--animate-delay');
+			return;
+		}
+
+		// Apply animation classes for blocks that have animations
+		applyAnimateClasses(blockElement, animationSettings.type, animationSettings.trigger);
+
+		// Set CSS custom properties for when preview is triggered
+		if (animationSettings.duration) {
+			blockElement.style.setProperty('--animate-duration', `${animationSettings.duration}ms`);
+		}
+		if (animationSettings.delay) {
+			blockElement.style.setProperty('--animate-delay', `${animationSettings.delay}ms`);
+		}
+	}, [clientId, animationSettings]);
+
+	return (
+		<InspectorControls>
+			<PanelBody
+				title={__('Animation', 'base-theme')}
+				initialOpen={false}
+			>
+				{animationSettings.type && (
+					<PanelRow>
+						<button
+							className="button button-secondary"
+							style={{ width: '100%', marginBottom: '16px' }}
+							onClick={() => {
+								triggerPreviewAnimation(
+									animationSettings.type,
+									animationSettings.duration || 1000,
+									animationSettings.delay || 0
+								);
+							}}
+							disabled={!animationSettings.type}
+						>
+							{__('Preview Animation', 'base-theme')}
+						</button>
+					</PanelRow>
+				)}
+
+				<PanelRow>
+					<SelectControl
+						label={__('Animation Type', 'base-theme')}
+						value={animationSettings.type || ''}
+						options={animationTypes}
+						onChange={(value) => updateAnimation('type', value)}
+						help={__('Choose the type of animation to apply to this block.', 'base-theme')}
+						__next40pxDefaultSize={true}
+						__nextHasNoMarginBottom={true}
+					/>
+				</PanelRow>
+
+				{animationSettings.type && (
+					<>
+						<PanelRow>
+							<SelectControl
+								label={__('Trigger', 'base-theme')}
+								value={animationSettings.trigger || 'scroll'}
+								options={triggerTypes}
+								onChange={(value) => updateAnimation('trigger', value)}
+								help={__('When should the animation be triggered?', 'base-theme')}
+								__next40pxDefaultSize={true}
+								__nextHasNoMarginBottom={true}
+							/>
+						</PanelRow>
+
+						<PanelRow>
+							<RangeControl
+								label={__('Duration (ms)', 'base-theme')}
+								value={animationSettings.duration || 500}
+								onChange={(value) => updateAnimation('duration', value)}
+								min={100}
+								max={3000}
+								step={100}
+								help={__('How long should the animation take to complete?', 'base-theme')}
+								__next40pxDefaultSize={true}
+								__nextHasNoMarginBottom={true}
+							/>
+						</PanelRow>
+
+						<PanelRow>
+							<RangeControl
+								label={__('Delay (ms)', 'base-theme')}
+								value={animationSettings.delay || 0}
+								onChange={(value) => updateAnimation('delay', value)}
+								min={0}
+								max={2000}
+								step={100}
+								help={__('How long to wait before starting the animation?', 'base-theme')}
+								__next40pxDefaultSize={true}
+								__nextHasNoMarginBottom={true}
+							/>
+						</PanelRow>
+
+						{animationSettings.trigger === 'scroll' && (
+							<PanelRow>
+								<RangeControl
+									label={__('Scroll Offset (%)', 'base-theme')}
+									value={animationSettings.scrollOffset || 75}
+									onChange={(value) => updateAnimation('scrollOffset', value)}
+									min={0}
+									max={100}
+									step={5}
+									help={__('How much of the element should be visible before triggering?', 'base-theme')}
+									__next40pxDefaultSize={true}
+									__nextHasNoMarginBottom={true}
+								/>
+							</PanelRow>
+						)}
+
+						<PanelRow>
+							<SelectControl
+								label={__('Easing', 'base-theme')}
+								value={animationSettings.easing || 'ease-out'}
+								options={[
+									{ label: __('Ease Out', 'base-theme'), value: 'ease-out' },
+									{ label: __('Ease In', 'base-theme'), value: 'ease-in' },
+									{ label: __('Ease In Out', 'base-theme'), value: 'ease-in-out' },
+									{ label: __('Linear', 'base-theme'), value: 'linear' },
+									{ label: __('Bounce', 'base-theme'), value: 'cubic-bezier(0.68, -0.55, 0.265, 1.55)' },
+								]}
+								onChange={(value) => updateAnimation('easing', value)}
+								help={__('The timing function for the animation.', 'base-theme')}
+								__next40pxDefaultSize={true}
+								__nextHasNoMarginBottom={true}
+							/>
+						</PanelRow>
+					</>
+				)}
+			</PanelBody>
+		</InspectorControls>
+	);
+};
+
+const addAnimationControls = (BlockEdit) => (props) => {
+	return (
+		<>
+			<BlockEdit {...props} />
+			<AnimationControls {...props} />
+		</>
+	);
+};
+
+addFilter(
+	'editor.BlockEdit',
+	'base-theme/animation-controls',
+	addAnimationControls
+);

--- a/resources/js/animation-editor.js
+++ b/resources/js/animation-editor.js
@@ -116,10 +116,35 @@ const AnimationControls = (props) => {
 	};
 
 	const updateAnimation = (key, value) => {
-		// If animation type is being set to empty/none, clear the entire animation attribute
-		if (key === 'type' && (!value || value === '')) {
+		// Handle "Global" selection (empty value) - remove animation attribute to use global defaults
+		if (key === 'type' && value === '') {
 			setAttributes({
-				animation: undefined, // Remove the animation attribute entirely
+				animation: undefined, // Remove the animation attribute entirely to use global defaults
+			});
+
+			// Remove animation classes from DOM element
+			const blockElement = document.querySelector(`[data-block="${clientId}"]`);
+			if (blockElement) {
+				// Remove all animate classes
+				const existingClasses = blockElement.className.split(' ').filter(cls =>
+					!cls.startsWith('animate__')
+				);
+				blockElement.className = existingClasses.join(' ').trim();
+
+				// Remove CSS custom properties
+				blockElement.style.removeProperty('--animate-duration');
+				blockElement.style.removeProperty('--animate-delay');
+			}
+			return;
+		}
+
+		// Handle "None" selection - explicitly save to override any global defaults
+		if (key === 'type' && value === 'none') {
+			setAttributes({
+				animation: {
+					source: 'block',
+					type: 'none', // Explicitly set to none to override global defaults
+				},
 			});
 
 			// Remove animation classes from DOM element
@@ -174,7 +199,8 @@ const AnimationControls = (props) => {
 	};
 
 	const animationTypes = [
-		{ label: __('None', 'base-theme'), value: '' },
+		{ label: __('None', 'base-theme'), value: 'none' },
+		{ label: __('Global', 'base-theme'), value: '' },
 		...Object.entries(l10n.supportedAnimateCssAnimations).map(([value, label]) => ({
 			label,
 			value
@@ -191,8 +217,8 @@ const AnimationControls = (props) => {
 		const blockElement = document.querySelector(`[data-block="${clientId}"]`);
 		if (!blockElement) return;
 
-		// If no animation type, clean up any existing animation classes
-		if (!animationSettings.type) {
+		// If no animation type or explicitly set to "none", clean up any existing animation classes
+		if (!animationSettings.type || animationSettings.type === 'none') {
 			// Remove all animate classes
 			const existingClasses = blockElement.className.split(' ').filter(cls =>
 				!cls.startsWith('animate__')
@@ -223,7 +249,7 @@ const AnimationControls = (props) => {
 				title={__('Animation', 'base-theme')}
 				initialOpen={false}
 			>
-				{animationSettings.type && (
+				{animationSettings.type && animationSettings.type !== 'none' && (
 					<PanelRow>
 						<button
 							className="button button-secondary"
@@ -254,7 +280,7 @@ const AnimationControls = (props) => {
 					/>
 				</PanelRow>
 
-				{animationSettings.type && (
+				{animationSettings.type && animationSettings.type !== 'none' && (
 					<>
 						<PanelRow>
 							<SelectControl

--- a/src/Domain/Animation.php
+++ b/src/Domain/Animation.php
@@ -336,22 +336,24 @@ final class Animation extends Service implements Registrable
 		if (
 			! empty( $block_animation ) &&
 			! empty( $block_animation['type'] ) &&
+			$block_animation['type'] !== 'none' &&
 			( $block_animation['source'] ?? 'block' ) === 'block'
 		) {
 			return $block_animation;
 		}
 
-		// If block has explicit empty animation (user chose "None"), respect that
+		// If block has explicit "none" animation (user chose "None"), respect that
 		if (
 			! empty( $block_animation ) &&
-			empty( $block_animation['type'] ) &&
+			$block_animation['type'] === 'none' &&
 			( $block_animation['source'] ?? 'block' ) === 'block'
 		) {
-			// Explicit "no animation"
+			// Explicit "no animation" - override any global defaults
 			return null;
 		}
 
-		// Check if this block type has default animations
+		// If block animation is empty or null, check for global defaults
+		// This handles the "Global" selection case
 		if ( isset( $this->default_block_animations[ $block_name ] ) ) {
 			$default_animation = $this->default_block_animations[ $block_name ];
 			// Mark as coming from global defaults

--- a/src/Domain/Animation.php
+++ b/src/Domain/Animation.php
@@ -31,6 +31,8 @@ final class Animation extends Service implements Registrable
 		'core/group',
 		'core/image',
 		'core/video',
+		'core/columns',
+		'core/column',
 	];
 
 	/**
@@ -47,6 +49,7 @@ final class Animation extends Service implements Registrable
 		'fadeInLeft' => 'Fade In Left',
 		'fadeInRight' => 'Fade In Right',
 		'fadeInUp' => 'Fade In Up',
+		'zoomIn' => 'Zoom In',
 	];
 
 	/**

--- a/src/Domain/Animation.php
+++ b/src/Domain/Animation.php
@@ -133,9 +133,7 @@ final class Animation extends Service implements Registrable
 			]
 		);
 
-		\wp_enqueue_script(
-			handle: 'animation-editor',
-		);
+		\wp_enqueue_script( handle: 'animation-editor' );
 	}
 
 	public function enqueueBlock(): void
@@ -189,11 +187,6 @@ final class Animation extends Service implements Registrable
 				'easing'       => 'ease-out',
 			],
 			'properties' => [
-				/**
-				 * Used to determine if the animation settings are from the block or global.
-				 *
-				 * @var string $source The source of the animation settings.
-				 */
 				'source' => [
 					'type' => 'string',
 				],
@@ -307,10 +300,12 @@ final class Animation extends Service implements Registrable
 
 			// Hide entrance animations initially
 			if ( $this->isEntranceAnimation( $animation_type ) ) {
-				$style_additions[] = "opacity: 0";
+				$style_additions[] = 'opacity: 0';
 			}
 
-			$new_style = $current_style ? $current_style . '; ' . \implode( '; ', $style_additions ) : \implode( '; ', $style_additions );
+			$new_style = $current_style
+				? $current_style . '; ' . \implode( '; ', $style_additions )
+				: \implode( '; ', $style_additions );
 			$processor->set_attribute( 'style', $new_style );
 
 			$modified_content = $processor->get_updated_html();
@@ -335,26 +330,32 @@ final class Animation extends Service implements Registrable
 	 * @param string $block_name The block type name.
 	 * @return array<string, mixed>|null Effective animation settings or null if no animation.
 	 */
-	private function getEffectiveAnimation( ?array $block_animation, string $block_name ): ?array
+	private function getEffectiveAnimation( null|array $block_animation, string $block_name ): null|array
 	{
 		// If block has explicit animation settings with source 'block', use them
-		if ( ! empty( $block_animation ) &&
-			 ! empty( $block_animation['type'] ) &&
-			 ( $block_animation['source'] ?? 'block' ) === 'block' ) {
+		if (
+			! empty( $block_animation ) &&
+			! empty( $block_animation['type'] ) &&
+			( $block_animation['source'] ?? 'block' ) === 'block'
+		) {
 			return $block_animation;
 		}
 
 		// If block has explicit empty animation (user chose "None"), respect that
-		if ( ! empty( $block_animation ) &&
-			 empty( $block_animation['type'] ) &&
-			 ( $block_animation['source'] ?? 'block' ) === 'block' ) {
-			return null; // Explicit "no animation"
+		if (
+			! empty( $block_animation ) &&
+			empty( $block_animation['type'] ) &&
+			( $block_animation['source'] ?? 'block' ) === 'block'
+		) {
+			// Explicit "no animation"
+			return null;
 		}
 
 		// Check if this block type has default animations
 		if ( isset( $this->default_block_animations[ $block_name ] ) ) {
 			$default_animation = $this->default_block_animations[ $block_name ];
-			$default_animation['source'] = 'global'; // Mark as coming from global defaults
+			// Mark as coming from global defaults
+			$default_animation['source'] = 'global';
 			return $default_animation;
 		}
 
@@ -371,9 +372,13 @@ final class Animation extends Service implements Registrable
 	 * @param int    $delay Animation delay in milliseconds.
 	 * @return string JavaScript code wrapped in script tags.
 	 */
-	private function generateScrollAnimationScript( string $element_id, int $scroll_offset, int $duration, int $delay ): string
-	{
-		$script = "
+	private function generateScrollAnimationScript(
+		string $element_id,
+		int $scroll_offset,
+		int $duration,
+		int $delay
+	): string {
+		return "
 		<script>
 		(function() {
 			const element = document.getElementById('{$element_id}');
@@ -405,8 +410,6 @@ final class Animation extends Service implements Registrable
 			observer.observe(element);
 		})();
 		</script>";
-
-		return $script;
 	}
 
 	/**

--- a/src/Domain/Animation.php
+++ b/src/Domain/Animation.php
@@ -1,0 +1,458 @@
+<?php
+
+/**
+ * Animation
+ *
+ * @package   Vatu\Wordpress\Theme\Client\BaseTheme
+ * @author    Vatu <hello@vatu.dev>
+ * @link      https://vatu.dev/
+ * @license   GNU General Public License v3.0 or later
+ * @copyright 2025 Vatu Limited.
+ */
+
+declare(strict_types=1);
+
+namespace Client\BaseTheme\Domain;
+
+use ThoughtsIdeas\Wordpress\Infrastructure\Services\Registrable;
+use ThoughtsIdeas\Wordpress\Infrastructure\Services\Service;
+
+final class Animation extends Service implements Registrable
+{
+	protected string $name = 'Animation';
+
+	/**
+	 * @var array<string>
+	 */
+	private array $supported_blocks = [
+		'core/heading',
+		'core/paragraph',
+		'core/list',
+		'core/group',
+		'core/image',
+		'core/video',
+	];
+
+	/**
+	 * Supported Animate.css animations.
+	 *
+	 * @link https://animate.style/
+	 *
+	 * @var array<string>
+	 */
+	private array $supported_animate_css_animations = [
+		// Fade in animations
+		'fadeIn' => 'Fade In',
+		'fadeInDown' => 'Fade In Down',
+		'fadeInLeft' => 'Fade In Left',
+		'fadeInRight' => 'Fade In Right',
+		'fadeInUp' => 'Fade In Up',
+	];
+
+	/**
+	 * Supported trigger types.
+	 *
+	 * @var array<string>
+	 */
+	private array $supported_trigger_types = [
+		'scroll' => 'Scroll',
+	];
+
+	/**
+	 * Default animations for specific block types.
+	 *
+	 * @var array<string, array<string, mixed>>
+	 */
+	private array $default_block_animations = [
+		'core/heading' => [
+			'type'         => 'fadeIn',
+			'trigger'      => 'scroll',
+			'duration'     => 800,
+			'delay'        => 100,
+			'scrollOffset' => 20,
+			'repeat'       => false,
+			'easing'       => 'ease-out',
+		],
+	];
+
+	public function register(): void
+	{
+		\add_action(
+			hook_name: 'enqueue_block_editor_assets',
+			callback: [ $this, 'enqueueBlockEditor' ],
+			priority: 10,
+			accepted_args: 0
+		);
+
+		\add_action(
+			hook_name: 'enqueue_block_assets',
+			callback: [ $this, 'enqueueBlock' ],
+			priority: 10,
+			accepted_args: 0
+		);
+
+		\add_filter(
+			hook_name: 'block_type_metadata',
+			callback: [ $this, 'addAnimationAttributes' ],
+			priority: 10,
+			accepted_args: 1
+		);
+
+		\add_filter(
+			hook_name: 'render_block',
+			callback: [ $this, 'renderBlockWithAnimation' ],
+			priority: 10,
+			accepted_args: 2
+		);
+	}
+
+	public function enqueueBlockEditor(): void
+	{
+		$script_asset_file = \get_theme_file_path( 'assets/js/animation-editor.asset.php' );
+		$script_asset = file_exists( $script_asset_file ) ? include_once $script_asset_file : [];
+
+		// Ensure we have a valid asset array structure
+		if ( ! is_array( $script_asset ) ) {
+			$script_asset = [];
+		}
+
+		\wp_register_script(
+			handle: 'animation-editor',
+			src: \get_theme_file_uri( file: '/assets/js/animation-editor.js' ),
+			deps: $script_asset['dependencies'] ?? [],
+			ver: $script_asset['version'] ?? '1.0.0'
+		);
+
+		wp_localize_script(
+			handle: 'animation-editor',
+			object_name: 'l10n',
+			l10n: [
+				'supportedBlocks'               => $this->getSupportedBlocks(),
+				'supportedAnimateCssAnimations' => $this->getSupportedAnimateCssAnimations(),
+				'supportedTriggerTypes' => $this->getSupportedTriggerTypes(),
+			]
+		);
+
+		\wp_enqueue_script(
+			handle: 'animation-editor',
+		);
+	}
+
+	public function enqueueBlock(): void
+	{
+		\wp_enqueue_style(
+			handle: 'animate-css',
+			src: 'https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css'
+		);
+
+		// Enqueue animation editor CSS for both editor and frontend
+		$style_asset_file = \get_theme_file_path( 'assets/css/animation-editor.asset.php' );
+		$style_asset = file_exists( $style_asset_file ) ? include_once $style_asset_file : [];
+
+		// Ensure we have a valid asset array structure
+		if ( ! is_array( $style_asset ) ) {
+			$style_asset = [];
+		}
+
+		\wp_enqueue_style(
+			handle: 'animation-editor',
+			src: \get_theme_file_uri( file: '/assets/css/animation-editor.css' ),
+			deps: $style_asset['dependencies'] ?? [],
+			ver: $style_asset['version'] ?? '1.0.0'
+		);
+	}
+
+	/**
+	 * Add animation attributes to all block types.
+	 *
+	 * @param array<string, mixed> $metadata Block type metadata.
+	 * @return array<string, mixed> Modified metadata with animation attributes.
+	 */
+	public function addAnimationAttributes( array $metadata ): array
+	{
+		// Skip if attributes are not set (shouldn't happen, but safety first)
+		if ( ! isset( $metadata['attributes'] ) ) {
+			$metadata['attributes'] = [];
+		}
+
+		// Add grouped animation attribute with nested properties
+		$metadata['attributes']['animation'] = [
+			'type'    => 'object',
+			'default' => [
+				'source'       => 'block',
+				'type'         => '',
+				'trigger'      => 'scroll',
+				'duration'     => 1000,
+				'delay'        => 0,
+				'scrollOffset' => 20,
+				'repeat'       => false,
+				'easing'       => 'ease-out',
+			],
+			'properties' => [
+				/**
+				 * Used to determine if the animation settings are from the block or global.
+				 *
+				 * @var string $source The source of the animation settings.
+				 */
+				'source' => [
+					'type' => 'string',
+				],
+				'type' => [
+					'type' => 'string',
+				],
+				'trigger' => [
+					'type' => 'string',
+				],
+				'duration' => [
+					'type' => 'number',
+				],
+				'delay' => [
+					'type' => 'number',
+				],
+				'scrollOffset' => [
+					'type' => 'number',
+				],
+				'repeat' => [
+					'type' => 'boolean',
+				],
+				'easing' => [
+					'type' => 'string',
+				],
+			],
+		];
+
+		return $metadata;
+	}
+
+	/**
+	 * Filter block rendering to check for animation attributes.
+	 *
+	 * @param string $block_content The block content.
+	 * @param array<string, mixed> $block The full block, including name and attributes.
+	 * @return string Modified block content.
+	 */
+	public function renderBlockWithAnimation( string $block_content, array $block ): string
+	{
+		// Get the block name for checking defaults
+		$block_name = $block['blockName'] ?? '';
+
+		// Check if the block has animation attributes
+		$animation = $block['attrs']['animation'] ?? null;
+
+		// Determine animation settings (block-specific or defaults)
+		$final_animation = $this->getEffectiveAnimation( $animation, $block_name );
+
+		// If no effective animation, return content unchanged
+		if ( empty( $final_animation ) || empty( $final_animation['type'] ) ) {
+			return $block_content;
+		}
+
+		$animation_type = $final_animation['type'];
+		$animation_trigger = $final_animation['trigger'] ?? 'scroll';
+		$animation_duration = $final_animation['duration'] ?? 1000;
+		$animation_delay = $final_animation['delay'] ?? 0;
+		$animation_scroll_offset = $final_animation['scrollOffset'] ?? 20;
+
+		// Only handle scroll trigger animations for now
+		if ( $animation_trigger === 'scroll' ) {
+			return $this->handleScrollAnimation(
+				$block_content,
+				$animation_type,
+				$animation_duration,
+				$animation_delay,
+				$animation_scroll_offset
+			);
+		}
+
+		// For now, we only support scroll triggers
+		return $block_content;
+	}
+
+	/**
+	 * Handle scroll-triggered animations.
+	 *
+	 * @param string $block_content The block content.
+	 * @param string $animation_type The animation type.
+	 * @param int    $duration Animation duration in milliseconds.
+	 * @param int    $delay Animation delay in milliseconds.
+	 * @param int    $scroll_offset Scroll offset percentage.
+	 * @return string Modified block content with scroll animation support.
+	 */
+	private function handleScrollAnimation(
+		string $block_content,
+		string $animation_type,
+		int $duration,
+		int $delay,
+		int $scroll_offset
+	): string {
+		// Generate a unique ID for this animated block
+		$unique_id = 'animate-' . \uniqid();
+
+		// Use HTML_Tag_Processor to add the ID to the first element
+		$processor = new \WP_HTML_Tag_Processor( $block_content );
+
+		if ( $processor->next_tag() ) {
+			// Add unique ID
+			$processor->set_attribute( 'id', $unique_id );
+
+			// Add data attributes for animation configuration (only what we need)
+			$processor->set_attribute( 'data-animate-type', $animation_type );
+
+			$current_style = $processor->get_attribute( 'style' ) ?? '';
+
+			// Add CSS custom properties for animation timing
+			$style_additions = [];
+			$style_additions[] = "--animate-duration: {$duration}ms";
+			$style_additions[] = "--animate-delay: {$delay}ms";
+
+			// Hide entrance animations initially
+			if ( $this->isEntranceAnimation( $animation_type ) ) {
+				$style_additions[] = "opacity: 0";
+			}
+
+			$new_style = $current_style ? $current_style . '; ' . \implode( '; ', $style_additions ) : \implode( '; ', $style_additions );
+			$processor->set_attribute( 'style', $new_style );
+
+			$modified_content = $processor->get_updated_html();
+		} else {
+			// Fallback if no HTML tags found
+			$modified_content = $block_content;
+		}
+
+		// Generate the JavaScript for scroll detection
+		$script = $this->generateScrollAnimationScript( $unique_id, $scroll_offset, $duration, $delay );
+
+		return $modified_content . $script;
+	}
+
+	/**
+	 * Get the effective animation settings for a block.
+	 *
+	 * This method determines whether to use block-specific animation settings
+	 * or fall back to default animations for the block type.
+	 *
+	 * @param array<string, mixed>|null $block_animation Block-specific animation settings.
+	 * @param string $block_name The block type name.
+	 * @return array<string, mixed>|null Effective animation settings or null if no animation.
+	 */
+	private function getEffectiveAnimation( ?array $block_animation, string $block_name ): ?array
+	{
+		// If block has explicit animation settings with source 'block', use them
+		if ( ! empty( $block_animation ) &&
+			 ! empty( $block_animation['type'] ) &&
+			 ( $block_animation['source'] ?? 'block' ) === 'block' ) {
+			return $block_animation;
+		}
+
+		// If block has explicit empty animation (user chose "None"), respect that
+		if ( ! empty( $block_animation ) &&
+			 empty( $block_animation['type'] ) &&
+			 ( $block_animation['source'] ?? 'block' ) === 'block' ) {
+			return null; // Explicit "no animation"
+		}
+
+		// Check if this block type has default animations
+		if ( isset( $this->default_block_animations[ $block_name ] ) ) {
+			$default_animation = $this->default_block_animations[ $block_name ];
+			$default_animation['source'] = 'global'; // Mark as coming from global defaults
+			return $default_animation;
+		}
+
+		// No animation
+		return null;
+	}
+
+	/**
+	 * Generate JavaScript for scroll-triggered animations.
+	 *
+	 * @param string $element_id The unique element ID.
+	 * @param int    $scroll_offset Scroll offset percentage.
+	 * @param int    $duration Animation duration in milliseconds.
+	 * @param int    $delay Animation delay in milliseconds.
+	 * @return string JavaScript code wrapped in script tags.
+	 */
+	private function generateScrollAnimationScript( string $element_id, int $scroll_offset, int $duration, int $delay ): string
+	{
+		$script = "
+		<script>
+		(function() {
+			const element = document.getElementById('{$element_id}');
+			if (!element) return;
+
+			const animationType = element.getAttribute('data-animate-type');
+
+			// Set CSS custom properties directly from PHP values
+			element.style.setProperty('--animate-duration', '{$duration}ms');
+			element.style.setProperty('--animate-delay', '{$delay}ms');
+
+			// Intersection Observer for scroll detection
+			const observer = new IntersectionObserver((entries) => {
+				entries.forEach(entry => {
+					if (entry.isIntersecting) {
+						// Show element if it was hidden (entrance animations)
+						entry.target.style.opacity = '1';
+						// Add animation classes
+						entry.target.classList.add('animate__animated', 'animate__' + animationType);
+						// Stop observing once animated
+						observer.unobserve(entry.target);
+					}
+				});
+			}, {
+				threshold: {$scroll_offset} / 100,
+				rootMargin: '0px'
+			});
+
+			observer.observe(element);
+		})();
+		</script>";
+
+		return $script;
+	}
+
+	/**
+	 * @return array<string>
+	 */
+	private function getSupportedBlocks(): array
+	{
+		return $this->supported_blocks;
+	}
+
+	/**
+	 * @return array<string, string>
+	 */
+	private function getSupportedAnimateCssAnimations(): array
+	{
+		return $this->supported_animate_css_animations;
+	}
+
+	/**
+	 * @return array<string, string>
+	 */
+	private function getSupportedTriggerTypes(): array
+	{
+		return $this->supported_trigger_types;
+	}
+
+	/**
+	 * Check if an animation type is an entrance animation that should start hidden.
+	 *
+	 * @param string $animation_type The animation type to check.
+	 * @return bool True if it's an entrance animation.
+	 */
+	private function isEntranceAnimation( string $animation_type ): bool
+	{
+		// List of entrance animation patterns
+		$entrance_patterns = [
+			'fadeIn',
+		];
+
+		// Check if animation type starts with any entrance pattern
+		foreach ( $entrance_patterns as $pattern ) {
+			if ( \str_starts_with( $animation_type, $pattern ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/src/Theme.php
+++ b/src/Theme.php
@@ -32,6 +32,7 @@ final class Theme extends ServiceProvider implements Main
 	 * @var array<string>
 	 */
 	protected array $service_collection = [
+		Domain\Animation::class,
 		Domain\ArchiveTitle::class,
 		Domain\BlockEditor::class,
 		Domain\BlockPatterns::class,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,6 +57,10 @@ module.exports = (env) => {
 			entry: {
 				...getWebpackEntryPoints,
 				...blockStylesheets(),
+				animationEditor: {
+					import: path.resolve(ThemePath, "resources/js/", "animation-editor.js"),
+					filename: "js/animation-editor.js",
+				},
 				editor: {
 					import: path.resolve(ThemePath, "resources/js/", "editor.js"),
 					filename: "js/[name].js",
@@ -70,6 +74,9 @@ module.exports = (env) => {
 				},
 				"css/editor": {
 					import: path.resolve(ThemePath, "resources/css/", "editor.css"),
+				},
+				"css/animation-editor": {
+					import: path.resolve(ThemePath, "resources/css/", "animation-editor.css"),
 				},
 			},
 			output: {


### PR DESCRIPTION
### Summary

This PR introduces a **WIP MVP animation service** that integrates [Animate.css](https://animate.style/) for block animations.  

### How it works
- Each [supported block](https://github.com/vatu-team/base-theme/pull/195/files#diff-4fcd2777dfd8997e0c93a67d5f13fb391fceeaa4aec2670b665cd7c43d8cb35dR27-R34) now has a new **Animation panel** in the block sidebar:  

<img width="300" alt="CleanShot 2025-09-26 at 20 01 22@2x" src="https://github.com/user-attachments/assets/b7ad34dc-654d-4ab1-8a0c-5fc3bab31975" />

- Configuring an animation saves the options as **block attributes** and updates the DOM in the editor so the **Preview Animation** button works.
- On the frontend, animations are applied by hooking into the `render_block` filter.

### Global configuration
Animations can also be applied globally via code.  
For example, the heading block is configured with a global animation [here](https://github.com/vatu-team/base-theme/pull/195/files#diff-4fcd2777dfd8997e0c93a67d5f13fb391fceeaa4aec2670b665cd7c43d8cb35dR66-R76).  

### Notes
This is still very much a **WIP**, but provides a framework we can extend.  
- Built to work with Animate.css out of the box.  
- Designed to be expandable with custom animations for future projects.  

### To-do / Improvements
- Integrate with `theme.json` for default animation speeds.  
- Replace CDN-loaded Animate.css with a better asset strategy.  
